### PR TITLE
Fixed PMA URL to the new one

### DIFF
--- a/bin/pma_create_day
+++ b/bin/pma_create_day
@@ -30,7 +30,7 @@ endtime=${endtime-'18:00'}
 interval=${interval-'01:00'}
 
 
-resp=$(curl -s -X post https://pma.dextra.com.br/pma/services/criar_apontamento_diario -d token=$(cat $HOME/.pma_token)\&data=$date\&inicio=$starttime\&intervalo=$interval\&fim=$endtime)
+resp=$(curl -s -X post https://dextranet.dextra.com.br/pma/services/criar_apontamento_diario -d token=$(cat $HOME/.pma_token)\&data=$date\&inicio=$starttime\&intervalo=$interval\&fim=$endtime)
 
 source pma_util
 handlePmaResponse "$resp"

--- a/bin/pma_create_task
+++ b/bin/pma_create_task
@@ -38,7 +38,7 @@ shift
 description=${@-'Devel'}
 description=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "$description")
 
-resp=$(curl -s -X post https://pma.dextra.com.br/pma/services/criar_apontamento -d token=$(cat $HOME/.pma_token)\&data=$date\&atividadeId=$task\&atividadeStatus=$stat\&esforco=$effort\&descricao=$description)
+resp=$(curl -s -X post https://dextranet.dextra.com.br/pma/services/criar_apontamento -d token=$(cat $HOME/.pma_token)\&data=$date\&atividadeId=$task\&atividadeStatus=$stat\&esforco=$effort\&descricao=$description)
 
 source pma_util
 handlePmaResponse "$resp"

--- a/bin/pma_list
+++ b/bin/pma_list
@@ -4,7 +4,7 @@ source pma_util
 
 function list() {
   date=$1
-  resp=$(curl -s -X post https://pma.dextra.com.br/pma/services/listar_apontamentos -d token=$(cat $HOME/.pma_token)\&data=$date)
+  resp=$(curl -s -X post https://dextranet.dextra.com.br/pma/services/listar_apontamentos -d token=$(cat $HOME/.pma_token)\&data=$date)
 
   handlePmaResponse "$resp"
 

--- a/bin/pma_logout
+++ b/bin/pma_logout
@@ -6,7 +6,7 @@ source pma_util
 
 readPass "$username"
 
-resp=$(curl -s -X post https://pma.dextra.com.br/pma/services/invalidar_tokens -d username=$username\&password=$password)
+resp=$(curl -s -X post https://dextranet.dextra.com.br/pma/services/invalidar_tokens -d username=$username\&password=$password)
 
 handlePmaResponse "$resp"
 

--- a/bin/pma_projects
+++ b/bin/pma_projects
@@ -1,7 +1,7 @@
 #!/bin/bash 
 
 source pma_util
-resp=$(curl -s -X post https://pma.dextra.com.br/pma/services/listar_projetos -d token=$(cat $HOME/.pma_token)) 
+resp=$(curl -s -X post https://dextranet.dextra.com.br/pma/services/listar_projetos -d token=$(cat $HOME/.pma_token)) 
 handlePmaResponse "$resp"
 
 if [ $response_code != '0' ]; then

--- a/bin/pma_tasks
+++ b/bin/pma_tasks
@@ -9,7 +9,7 @@ source pma_util
 function tasks() {
   projectid=$1
 
-  resp=$(curl -s -X post https://pma.dextra.com.br/pma/services/listar_atividades -d token=$(cat $HOME/.pma_token)\&projeto=$projectid)
+  resp=$(curl -s -X post https://dextranet.dextra.com.br/pma/services/listar_atividades -d token=$(cat $HOME/.pma_token)\&projeto=$projectid)
 
   handlePmaResponse "$resp"
 

--- a/bin/pma_token
+++ b/bin/pma_token
@@ -6,7 +6,7 @@ source pma_util
 
 readPass "$username"
 
-resp=$(curl -s -X post https://pma.dextra.com.br/pma/services/obter_token -d username=$username\&password=$password)
+resp=$(curl -s -X post https://dextranet.dextra.com.br/pma/services/obter_token -d username=$username\&password=$password)
 
 handlePmaResponse "$resp"
 


### PR DESCRIPTION
The URL to the PMA changed to a new one. The old one still redirects to the correct location, but apparently the script does not handle HTTP redirection, so the URL needed to be changed.
